### PR TITLE
pkg/util/log: enable bufferedSink usage with fileSink as experimental

### DIFF
--- a/rand454324.txt
+++ b/rand454324.txt
@@ -1,1 +1,2 @@
 wekfenkng
+sdsd

--- a/rand454324.txt
+++ b/rand454324.txt
@@ -1,0 +1,1 @@
+wekfenkng


### PR DESCRIPTION
Informs: https://github.com/cockroachdb/cockroach/issues/72452

Epic: CRDB-35401

For some time, two buffering mechanisms have existed within the log
package. One is controlled by `buffered-writes`, which is only used by
the file sink. `buffered-writes` buffers writes until a buffer is full,
after which it flushes the buffer to an underlying file. This is not an
asynchronous operation.

Separately, the `bufferedSink` was introduced to provide an async
buffering mechanism. This was originally intended for network log sinks
such as the `fluentSink` and `httpSink`. Originally, the `bufferedSink`
was not allowed for use with the `fileSink` as we already had a
buffering mechanism available.

Today, we find ourselves in a situation where we aim to make CRDB even
more resilient in the face of disk failures. However, some of these
efforts like WAL failover are unable to achieve their goals if the
logging subsystem isn't resilient to disk unavailability as well.

Today, if a file sink is configured to write to an unavailable disk, any
goroutine making a logging call to one of those sinks will hang as the
underlying i/o operations used are unable to interact with the disk.
This can have a severe negative impact on cluster performance and
throughput, even when using `buffered-writes: true`.

As a way to alleviate this pain, this patch experimentally enables the
usage of the `bufferedSink` with the `fileSink`. The `bufferedSink` is
used to "wrap" an underlying sink (such as a `fileSink`), and
asynchronously outputs buffered data to said sink. It is especially good
at shielding writers from any problems with the underlying sink, which
makes it a great candidate to help us accomplish our resiliency goals
when it comes to disk outage scenarios.

Users can leverage the `bufferedSink` by using the `buffering` config option. 
For example:

```
file-defaults:
  buffered-writes: false
  buffering:
    max-staleness: 5s
    flush-trigger-size: 1.0MiB
    max-buffer-size: 50MiB
```

Note that we don't allow both `buffered-writes` and `buffering` to be
used together. This patch adds a validation step to ensure this.

Release note (ops change): Users have the ability to update their log
configuration to enable asynchronous buffering of `file-group` log
sinks via the `buffering` [configuration
options](https://www.cockroachlabs.com/docs/stable/configure-logs#log-buffering-for-network-sinks).

The `buffering` configuration can be applied to `file-defaults` or
individual `file-groups` as needed.

Note however that `buffering` and `buffered-writes` are incompatible for
the time being. If you'd like to try the `buffering` option on a file
log sink, it's necessary to explicitly set `buffered-writes: false`. For
example:
```
file-defaults:
  buffered-writes: false
  buffering:
    max-staleness: 1s
    flush-trigger-size: 256KiB
    max-buffer-size: 50MiB
```
We recommend a `max-staleness: 1s` and `flush-trigger-size: 256KiB` when
using this feature with file log sinks.