### PR TITLE
vecindex: add BalancedKmeans class

### DIFF
--- a/aed.txt
+++ b/aed.txt
@@ -1,0 +1,1 @@
+vdfsfgsdf


### PR DESCRIPTION
BalancedKmeans implements a balanced K-Means algorithm that separates d-dimensional vectors into a left and right partition. Vectors in each of the resulting partition are more similar to their own partition than they are to the other partition (i.e. closer to the centroid of each partition). The size of each partition is guaranteed to have no less than 1/3rd of the vectors to be partitioned.

Epic: CRDB-42943

Release note (bug fix): Addressed a bug with DROP CASCADE that would occasionally panic with an undropped backref message on partitioned tables.